### PR TITLE
feat: only pick up items if they are from the same build mode

### DIFF
--- a/src/main/java/com/lovetropics/gamemodebuild/container/PlayerInventoryHooks.java
+++ b/src/main/java/com/lovetropics/gamemodebuild/container/PlayerInventoryHooks.java
@@ -3,6 +3,7 @@ package com.lovetropics.gamemodebuild.container;
 import com.lovetropics.gamemodebuild.client.BuildScreen;
 import com.lovetropics.gamemodebuild.message.OpenBuildInventoryMessage;
 import com.lovetropics.gamemodebuild.state.GBClientState;
+import com.lovetropics.gamemodebuild.state.GBPlayerStore;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.inventory.InventoryScreen;
 import net.minecraft.client.player.LocalPlayer;
@@ -11,7 +12,9 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.ScreenEvent;
+import net.neoforged.neoforge.common.util.TriState;
 import net.neoforged.neoforge.event.entity.item.ItemTossEvent;
+import net.neoforged.neoforge.event.entity.player.ItemEntityPickupEvent;
 import net.neoforged.neoforge.network.PacketDistributor;
 
 @EventBusSubscriber(value = Dist.CLIENT)
@@ -38,6 +41,13 @@ public final class PlayerInventoryHooks {
 	public static void onToss(ItemTossEvent event) {
 		if (GBStackMarker.isMarked(event.getEntity().getItem())) {
 			event.setCanceled(true);
+		}
+	}
+
+	@SubscribeEvent
+	public static void onPickup(ItemEntityPickupEvent.Pre event) {
+		if (GBStackMarker.isMarked(event.getItemEntity().getItem()) != GBPlayerStore.isActive(event.getPlayer())) {
+			event.setCanPickup(TriState.FALSE);
 		}
 	}
 }


### PR DESCRIPTION
This should fix #7 as well as avoid having items not from the build mode menu being able to get into there. Hoever if we dont have the block drops off the blocks dropped would still spawn without the tag so not sure if this 100% fixes the issue.